### PR TITLE
geogebra-classic.install agora é geogebra6

### DIFF
--- a/win_classroom/tasks/main.yml
+++ b/win_classroom/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Instala programas usados nas máquinas de sala de aula
   win_chocolatey:
     name:
-      - geogebra-classic.install
+      - geogebra6
       - gimp
       - inkscape
       - miktex


### PR DESCRIPTION
geogebra-classic.install não funciona mais, agora é geogebra6