### PR TITLE
Revert "win_classroom: usuário aula agora é um usuário normal"

### DIFF
--- a/win_classroom/tasks/main.yml
+++ b/win_classroom/tasks/main.yml
@@ -28,7 +28,7 @@
     password_never_expires: yes
     state: present
     groups:
-      - 'Usuários'
+      - 'Convidados'
 
 - name: Define o usuário do login automático para o usuário aula
   ansible.windows.win_regedit:


### PR DESCRIPTION
This reverts commit e8d80bff8fe5964b9b1ade87842460fff911398a.

Usuário normal expôs recursos demais, incluindo associar a uma conta Microsoft.